### PR TITLE
BUGFIX blocks not removed on new record

### DIFF
--- a/code/dataobjects/CatalogProduct.php
+++ b/code/dataobjects/CatalogProduct.php
@@ -181,10 +181,6 @@ class CatalogProduct extends DataObject implements PermissionProvider, Dynamic\V
                 'DisabledBlocks',
             ];
 
-            if (!$this->ID) {
-                $remove[] = 'Blocks';
-            }
-
             $fields->removeByName($remove);
 
             $fields->insertBefore(
@@ -257,7 +253,13 @@ class CatalogProduct extends DataObject implements PermissionProvider, Dynamic\V
                 $inquiries->setConfig($inquiriesConfig = GridFieldConfig_RecordViewer::create());
             }
         });
-        return parent::getCMSFields();
+        $fields = parent::getCMSFields();
+
+        if (!$this->exists()) {
+            $fields->removeByName('Blocks');
+        }
+
+        return $fields;
     }
 
     /**


### PR DESCRIPTION
Removing blocks before the updateCMSFields() allows DataExtension to re-add causing sort order errors on new records.