### PR TITLE
Now allows the meta tags to return without the title

### DIFF
--- a/code/pages/CatalogCategory.php
+++ b/code/pages/CatalogCategory.php
@@ -137,6 +137,11 @@ class CatalogCategory_Controller extends Page_Controller
     );
 
     /**
+     * @var bool
+     */
+    private static $include_meta_tag_title = true;
+
+    /**
      * @var
      */
     private $product;
@@ -200,11 +205,10 @@ class CatalogCategory_Controller extends Page_Controller
         if (!$product) {
             return $this->httpError(404, 'The product you\'re looking for isn\'t available.');
         }
-
         return $this->customise(array(
-            'Title' => $product->getTitle(),
+            'Title' => $product->MetaTitle ? $product->MetaTitle : $product->Title,
             'Product' => $product,
-            'MetaTags' => $product->MetaTags(),
+            'MetaTags' => $product->MetaTags($this->config()->get('include_meta_tag_title')),
             'Breadcrumbs' => $product->Breadcrumbs(),
             'AllowInquiries' => $product->AllowInquiry,
             'ProductInquiryForm' => $this->ProductInquiryForm(),


### PR DESCRIPTION
  - default is still `MetaTags(true)`
  - set `include_meta_tag_title` to false to use `MetaTags(false)`
  - Title in the template now returns MetaTitle if it is set, otherwise it returns the title (for the page title)